### PR TITLE
Issue004

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
   - "3.5"
 # command to install dependencies
 install:
-  - "pip install pipenv"
+  - "export PIPENV_IGNORE_VIRTUALENVS=1"
+  - "pip install pipenv==8.2.7"
   - "pipenv install --dev"
 script:
   - pipenv run nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - PIPENV_IGNORE_VIRTUALENVS=1
 # command to install dependencies
 install:
-  - "pip install pipenv==8.2.7"
+  - "pip install pipenv"
   - "pipenv install --dev"
   - "pipenv run pip list --format=freeze"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ install:
   - "export PIPENV_IGNORE_VIRTUALENVS=1"
   - "pip install pipenv==8.2.7"
   - "pipenv install --dev"
+  - "pipenv run pip list --format=freeze"
 script:
   - pipenv run nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ python:
   - "3.6"
   - "3.4"
   - "3.5"
+env:
+  - PIPENV_IGNORE_VIRTUALENVS=1
 # command to install dependencies
 install:
-  - "export PIPENV_IGNORE_VIRTUALENVS=1"
   - "pip install pipenv==8.2.7"
   - "pipenv install --dev"
   - "pipenv run pip list --format=freeze"

--- a/Pipfile
+++ b/Pipfile
@@ -7,13 +7,13 @@ name = "pypi"
 
 [packages]
 
-requests = "==2.18.4"
+requests = "==2.18.*"
 logzero = "==1.*"
 
 
 [dev-packages]
 
-nose = "==1.3.7"
+nose = "*"
 vcrpy-unittest = "==0.1.*"
 sphinx = "==1.6.5"
 vcrpy = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -7,8 +7,8 @@ name = "pypi"
 
 [packages]
 
-requests = "==2.18.*"
-logzero = "==1.*"
+requests = "<2.19"
+logzero = "*"
 
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ name = "pypi"
 [packages]
 
 requests = "==2.18.4"
-logzero = "==1.3.1"
+logzero = "==1.*"
 
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -7,16 +7,16 @@ name = "pypi"
 
 [packages]
 
-requests = "*"
-logzero = "*"
+requests = "==2.18.4"
+logzero = "==1.3.1"
 
 
 [dev-packages]
 
-nose = "*"
-ipython = "*"
-vcrpy-unittest = "*"
-sphinx = "*"
+nose = "==1.3.7"
+vcrpy-unittest = "==0.1.6"
+sphinx = "==1.6.5"
+vcrpy = "==1.11.1"
 
 
 [requires]

--- a/Pipfile
+++ b/Pipfile
@@ -14,9 +14,9 @@ logzero = "==1.*"
 [dev-packages]
 
 nose = "==1.3.7"
-vcrpy-unittest = "==0.1.6"
+vcrpy-unittest = "==0.1.*"
 sphinx = "==1.6.5"
-vcrpy = "==1.11.1"
+vcrpy = "*"
 
 
 [requires]


### PR DESCRIPTION
Updated dependencies to overcome the issue https://github.com/matthieudelaro/akeneo_api_client/issues/4.

The library works well, even thou tests fail. To make sure that they pass, the dependency version has been updated to requests = "<2.19"

A better fix would be to record the requests against a real server anew, with the new version of Requests.